### PR TITLE
Add Novita as a third LLM provider for generate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ from emboss import generate
 
 generate("Create a quarterly financial report",
          style="finance", output="report.pdf",
-         provider="anthropic")  # or "openai"
+         provider="anthropic")  # or "openai", "novita"
 ```
 
 **Tier 3: Markdown** (works with any LLM output):

--- a/src/emboss/generate.py
+++ b/src/emboss/generate.py
@@ -1206,7 +1206,7 @@ def generate(
         output: Optional file path to save the PDF
         provider: LLM provider ("anthropic", "openai", or "novita")
         model: Model name (defaults to claude-sonnet-5, gpt-4o, or
-            deepseek/deepseek-v4-pro)
+            moonshotai/kimi-k3)
         api_key: API key (or set ANTHROPIC_API_KEY / OPENAI_API_KEY /
             NOVITA_API_KEY env var)
         smart: Apply content intelligence to the parsed spec
@@ -1231,7 +1231,7 @@ def generate(
     elif provider == "openai":
         call, model = _call_openai, model or "gpt-4o"
     elif provider == "novita":
-        call, model = _call_novita, model or "deepseek/deepseek-v4-pro"
+        call, model = _call_novita, model or "moonshotai/kimi-k3"
     else:
         raise ValueError(
             f"Unknown provider: {provider!r}. Use 'anthropic', 'openai', or 'novita'."

--- a/src/emboss/generate.py
+++ b/src/emboss/generate.py
@@ -1184,7 +1184,7 @@ def generate(
     *,
     style: str = "corporate",
     output: str | None = None,
-    provider: Literal["anthropic", "openai"] = "anthropic",
+    provider: Literal["anthropic", "openai", "novita"] = "anthropic",
     model: str | None = None,
     api_key: str | None = None,
     smart: bool = False,
@@ -1204,9 +1204,11 @@ def generate(
         prompt: What document to create (e.g. "Write a quarterly financial report")
         style: Style preset (legal/finance/academic/corporate/minimal/journal/brief)
         output: Optional file path to save the PDF
-        provider: LLM provider ("anthropic" or "openai")
-        model: Model name (defaults to claude-sonnet-5 or gpt-4o)
-        api_key: API key (or set ANTHROPIC_API_KEY / OPENAI_API_KEY env var)
+        provider: LLM provider ("anthropic", "openai", or "novita")
+        model: Model name (defaults to claude-sonnet-5, gpt-4o, or
+            deepseek/deepseek-v4-pro)
+        api_key: API key (or set ANTHROPIC_API_KEY / OPENAI_API_KEY /
+            NOVITA_API_KEY env var)
         smart: Apply content intelligence to the parsed spec
         structured: Use constrained decoding (forced tool-use / JSON schema mode)
         max_repair_rounds: LLM correction rounds when validation fails
@@ -1228,9 +1230,11 @@ def generate(
         call, model = _call_anthropic, model or "claude-sonnet-5"
     elif provider == "openai":
         call, model = _call_openai, model or "gpt-4o"
+    elif provider == "novita":
+        call, model = _call_novita, model or "deepseek/deepseek-v4-pro"
     else:
         raise ValueError(
-            f"Unknown provider: {provider!r}. Use 'anthropic' or 'openai'."
+            f"Unknown provider: {provider!r}. Use 'anthropic', 'openai', or 'novita'."
         )
 
     strict = max_repair_rounds > 0
@@ -1356,6 +1360,54 @@ def _call_openai(
         ) from None
 
     client = OpenAI(api_key=api_key or os.environ.get("OPENAI_API_KEY"))
+    messages = [
+        {"role": "system", "content": system},
+        *(history or []),
+        {"role": "user", "content": prompt},
+    ]
+    kwargs: dict = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": 8192,
+        "temperature": 0.3,
+    }
+    if structured:
+        kwargs["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "emboss_spec",
+                "schema": _strict_schema(spec_schema()),
+                "strict": True,
+            },
+        }
+    response = client.chat.completions.create(**kwargs)
+    return response.choices[0].message.content
+
+
+def _call_novita(
+    prompt: str,
+    system: str,
+    model: str,
+    api_key: str | None,
+    *,
+    structured: bool = False,
+    history: list[dict] | None = None,
+) -> str:
+    """Call Novita AI's OpenAI-compatible Chat Completions API."""
+    import os
+
+    try:
+        from openai import OpenAI
+    except ImportError:
+        raise ImportError(
+            "openai package is required for generate() with provider='novita'.\n"
+            "  pip install openai"
+        ) from None
+
+    client = OpenAI(
+        base_url="https://api.novita.ai/openai",
+        api_key=api_key or os.environ.get("NOVITA_API_KEY"),
+    )
     messages = [
         {"role": "system", "content": system},
         *(history or []),

--- a/tests/test_llm_pipeline.py
+++ b/tests/test_llm_pipeline.py
@@ -243,9 +243,7 @@ class TestStructuredProviders:
     def test_novita_response_format_shape(self, monkeypatch):
         pytest.importorskip("pydantic")
         calls = _install_openai(monkeypatch, [json.dumps(VALID_SPEC)])
-        result = _call_novita(
-            "p", "s", "moonshotai/kimi-k3", "k", structured=True
-        )
+        result = _call_novita("p", "s", "moonshotai/kimi-k3", "k", structured=True)
         assert result == json.dumps(VALID_SPEC)
         response_format = calls[0]["response_format"]
         assert response_format["type"] == "json_schema"

--- a/tests/test_llm_pipeline.py
+++ b/tests/test_llm_pipeline.py
@@ -19,6 +19,7 @@ from emboss import (
 from emboss.generate import (
     _DOC_TYPE_EXEMPLARS,
     _call_anthropic,
+    _call_novita,
     _call_openai,
     _extract_json_candidate,
     _strict_schema,
@@ -59,7 +60,7 @@ def _install_anthropic(monkeypatch, responses):
     return calls
 
 
-def _install_openai(monkeypatch, contents):
+def _install_openai(monkeypatch, contents, clients=None):
     calls = []
 
     def _create(**kwargs):
@@ -69,8 +70,11 @@ def _install_openai(monkeypatch, contents):
         return SimpleNamespace(choices=[SimpleNamespace(message=message)])
 
     class FakeOpenAI:
-        def __init__(self, api_key=None):
+        def __init__(self, api_key=None, base_url=None):
             self.api_key = api_key
+            self.base_url = base_url
+            if clients is not None:
+                clients.append(self)
             self.chat = SimpleNamespace(completions=SimpleNamespace(create=_create))
 
     module = types.ModuleType("openai")
@@ -235,6 +239,38 @@ class TestStructuredProviders:
         pdf = generate("Write it", provider="openai", api_key="k")
         assert pdf.startswith(b"%PDF")
         assert calls[0]["response_format"]["type"] == "json_schema"
+
+    def test_novita_response_format_shape(self, monkeypatch):
+        pytest.importorskip("pydantic")
+        calls = _install_openai(monkeypatch, [json.dumps(VALID_SPEC)])
+        result = _call_novita(
+            "p", "s", "deepseek/deepseek-v4-pro", "k", structured=True
+        )
+        assert result == json.dumps(VALID_SPEC)
+        response_format = calls[0]["response_format"]
+        assert response_format["type"] == "json_schema"
+        assert response_format["json_schema"]["name"] == "emboss_spec"
+        assert response_format["json_schema"]["strict"] is True
+        _assert_strict(response_format["json_schema"]["schema"])
+
+    def test_novita_unstructured_omits_response_format(self, monkeypatch):
+        calls = _install_openai(monkeypatch, ["{}"])
+        _call_novita("p", "s", "deepseek/deepseek-v4-pro", "k", structured=False)
+        assert "response_format" not in calls[0]
+
+    def test_novita_uses_novita_base_url(self, monkeypatch):
+        clients = []
+        _install_openai(monkeypatch, ["{}"], clients=clients)
+        _call_novita("p", "s", "deepseek/deepseek-v4-pro", "k", structured=False)
+        assert clients[0].base_url == "https://api.novita.ai/openai"
+
+    def test_generate_structured_novita(self, monkeypatch):
+        pytest.importorskip("pydantic")
+        calls = _install_openai(monkeypatch, [json.dumps(VALID_SPEC)])
+        pdf = generate("Write it", provider="novita", api_key="k")
+        assert pdf.startswith(b"%PDF")
+        assert calls[0]["response_format"]["type"] == "json_schema"
+        assert calls[0]["model"] == "deepseek/deepseek-v4-pro"
 
 
 class TestRepairLoop:

--- a/tests/test_llm_pipeline.py
+++ b/tests/test_llm_pipeline.py
@@ -244,7 +244,7 @@ class TestStructuredProviders:
         pytest.importorskip("pydantic")
         calls = _install_openai(monkeypatch, [json.dumps(VALID_SPEC)])
         result = _call_novita(
-            "p", "s", "deepseek/deepseek-v4-pro", "k", structured=True
+            "p", "s", "moonshotai/kimi-k3", "k", structured=True
         )
         assert result == json.dumps(VALID_SPEC)
         response_format = calls[0]["response_format"]
@@ -255,13 +255,13 @@ class TestStructuredProviders:
 
     def test_novita_unstructured_omits_response_format(self, monkeypatch):
         calls = _install_openai(monkeypatch, ["{}"])
-        _call_novita("p", "s", "deepseek/deepseek-v4-pro", "k", structured=False)
+        _call_novita("p", "s", "moonshotai/kimi-k3", "k", structured=False)
         assert "response_format" not in calls[0]
 
     def test_novita_uses_novita_base_url(self, monkeypatch):
         clients = []
         _install_openai(monkeypatch, ["{}"], clients=clients)
-        _call_novita("p", "s", "deepseek/deepseek-v4-pro", "k", structured=False)
+        _call_novita("p", "s", "moonshotai/kimi-k3", "k", structured=False)
         assert clients[0].base_url == "https://api.novita.ai/openai"
 
     def test_generate_structured_novita(self, monkeypatch):
@@ -270,7 +270,7 @@ class TestStructuredProviders:
         pdf = generate("Write it", provider="novita", api_key="k")
         assert pdf.startswith(b"%PDF")
         assert calls[0]["response_format"]["type"] == "json_schema"
-        assert calls[0]["model"] == "deepseek/deepseek-v4-pro"
+        assert calls[0]["model"] == "moonshotai/kimi-k3"
 
 
 class TestRepairLoop:


### PR DESCRIPTION

## Summary

- Adds `provider="novita"` to `generate()`, calling Novita AI's OpenAI-compatible Chat Completions API (same request shape as `_call_openai`, only `base_url` and the default API key env var differ)
- Defaults to `moonshotai/kimi-k3` when no model is passed; reads `NOVITA_API_KEY` when no `api_key` is passed
- Updates the `provider` type hint, docstring, and error message; updates the README example to mention the new option

## Test Plan

- [x] All existing tests pass (`pytest`)
- [x] New tests added for new functionality
- [x] Linting clean (`ruff check src/ tests/`, `ruff format --check`)
- [x] Verified against the live Novita API (model catalog + a real chat completion) with a valid `NOVITA_API_KEY`
